### PR TITLE
implement and expose To_KV_RO.connect

### DIFF
--- a/lwt/mirage_fs_lwt.ml
+++ b/lwt/mirage_fs_lwt.ml
@@ -56,4 +56,6 @@ module To_KV_RO (FS: S) = struct
     | Error e -> Error (`FS e)
     | Ok stat -> Ok (stat.Mirage_fs.size)
 
+  let connect t = Lwt.return t
+
 end

--- a/lwt/mirage_fs_lwt.mli
+++ b/lwt/mirage_fs_lwt.mli
@@ -25,4 +25,7 @@ module type S = Mirage_fs.S
    and type page_aligned_buffer = Cstruct.t
 
 (** Consider a filesystem device as a key/value read-only store. *)
-module To_KV_RO (FS: S): Mirage_kv_lwt.RO with type t = FS.t
+module To_KV_RO (FS: S): sig
+  include Mirage_kv_lwt.RO with type t = FS.t
+  val connect : FS.t -> t io
+end


### PR DESCRIPTION
When a user tries to use `mirage configure --kv_ro=fat` without this patch, the unikernel is unbuildable.