### PR TITLE
README: Fix Markdown link; add Travis badge; add License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 ## mirage-fs — MirageOS signatures for filesystem devices
 
-mirage-fs provides the [Mirage_fs.S][fs] and [Mirage_fs_lwt.S] signatures
+mirage-fs provides the [Mirage_fs.S][fs] and [Mirage_fs_lwt.S][fslwt] signatures
 the MirageOS filesystem devices should implement.
-
-mirage-fs is distributed under the ISC license.
 
 [fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
 [fslwt]: http://mirage.github.io/mirage-fs/Mirage_fs_lwt.html
@@ -24,3 +22,9 @@ interfaces. It can be consulted [online][doc] or via `odig doc
 mirage-fs`.
 
 [doc]: https://mirage.github.io/mirage-fs/
+
+## License
+
+mirage-fs is distributed under the ISC license, see the [LICENSE.md] file for its text.
+
+[LICENSE.md]: ./LICENSE.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## mirage-fs — MirageOS signatures for filesystem devices
 
+[![Build Status](https://travis-ci.org/mirage/mirage-fs.svg?branch=master)](https://travis-ci.org/mirage/mirage-fs)
+
 mirage-fs provides the [Mirage_fs.S][fs] and [Mirage_fs_lwt.S][fslwt] signatures
 the MirageOS filesystem devices should implement.
 


### PR DESCRIPTION
This PR

- fixes a broken link in the first section, and
- adds a License section, to "keep the main thing the main thing", and
- uses a Travis badge in SVG (for extra shiny)