### PR TITLE
revise to mirage-kv-lwt 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
   - PINS="mirage-fs:. mirage-fs-lwt:."
   matrix:
-  - OCAML_VERSION=4.04 PACKAGE="mirage-fs-lwt"
+  - OCAML_VERSION=4.04 PACKAGE="mirage-fs"
   - OCAML_VERSION=4.05 PACKAGE="mirage-fs-lwt"
   - OCAML_VERSION=4.06 PACKAGE="mirage-fs-lwt"
+  - OCAML_VERSION=4.07 PACKAGE="mirage-fs-lwt"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### v2.0.0 (2019-02-27)
+
+* Adjust to mirage-kv-lwt 2.0.0 interface (@hannesm)
+
 ### v1.2.0 (2019-02-02)
 
 * Port to dune (@dinosaure)

--- a/lwt/mirage_fs_lwt.ml
+++ b/lwt/mirage_fs_lwt.ml
@@ -24,9 +24,11 @@ module To_KV_RO (FS: S) = struct
 
   type t = FS.t
   type +'a io = 'a Lwt.t
-  type page_aligned_buffer = FS.page_aligned_buffer
 
   type error = [ Mirage_kv.error | `FS of FS.error ]
+
+  type key = Mirage_kv.Key.t
+  type value = string
 
   let pp_error ppf = function
     | #Mirage_kv.error as e -> Mirage_kv.pp_error ppf e
@@ -34,26 +36,52 @@ module To_KV_RO (FS: S) = struct
 
   let disconnect t = FS.disconnect t
 
-  let mem t name =
+  let exists t key =
+    let name = Mirage_kv.Key.to_string key in
     FS.stat t name >|= function
-    | Ok _ -> Ok true
+    | Ok s ->
+      Ok (Some (if s.Mirage_fs.directory then `Dictionary else `Value))
     | Error `Not_a_directory
-    | Error `No_directory_entry -> Ok false
+    | Error `No_directory_entry -> Ok None
     | Error e -> Error (`FS e)
 
-  let read t name off len =
-    FS.read t name (Int64.to_int off) (Int64.to_int len) >|= function
-    | Error `Not_a_directory | Error `No_directory_entry ->
-      Error (`Unknown_key name)
-    | Error e -> Error (`FS e)
-    | Ok l -> Ok l
+  let get t key =
+    let name = Mirage_kv.Key.to_string key in
+    FS.stat t name >>= function
+    | Error `Is_a_directory -> Lwt.return (Error (`Value_expected key))
+    | Error `No_directory_entry -> Lwt.return (Error (`Not_found key))
+    | Error e -> Lwt.return (Error (`FS e))
+    | Ok s ->
+      FS.read t name 0 (Int64.to_int s.Mirage_fs.size) >|= function
+      | Error e -> Error (`FS e)
+      | Ok l -> Ok Cstruct.(to_string (concat l))
 
-  let size t name =
-    FS.stat t name >|= function
-    | Error `Not_a_directory
-    | Error `No_directory_entry -> Error (`Unknown_key name)
-    | Error e -> Error (`FS e)
-    | Ok stat -> Ok (stat.Mirage_fs.size)
+  let list t key =
+    let name = Mirage_kv.Key.to_string key in
+    let dict_or_value fn =
+      FS.stat t Mirage_kv.Key.(to_string (key / fn)) >|= function
+      | Error e -> Error (`FS e)
+      | Ok s -> Ok (if s.Mirage_fs.directory then `Dictionary else `Value)
+    in
+    FS.listdir t name >>= function
+    | Error `Not_a_directory -> Lwt.return (Error (`Dictionary_expected key))
+    | Error `No_directory_entry -> Lwt.return (Error (`Not_found key))
+    | Error e -> Lwt.return (Error (`FS e))
+    | Ok files ->
+      Lwt_list.fold_left_s (fun acc f ->
+          match acc with
+          | Error e -> Lwt.return (Error e)
+          | Ok acc -> dict_or_value f >|= function
+            | Error e -> Error e
+            | Ok t -> Ok ((f, t) :: acc))
+        (Ok []) files
+
+  let last_modified _ _ = Lwt.return (Ok (0, 0L))
+
+  let digest t key =
+    get t key >|= function
+    | Error e -> Error e
+    | Ok data -> Ok (Digest.string data)
 
   let connect t = Lwt.return t
 

--- a/mirage-fs-lwt.opam
+++ b/mirage-fs-lwt.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.05.0"}
   "dune" {build}
   "mirage-fs" {>= "1.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}

--- a/mirage-fs-lwt.opam
+++ b/mirage-fs-lwt.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {>= "2.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"


### PR DESCRIPTION
we don't get a `last_modified` from the FS.

This mirage-fs is on a deprecation path, I tried to update ocaml-fat with the newer Mirage_kv.RW interface, but that's pretty intricate. Instead, we can provide the same Mirage_kv.RO interface via Mirage_fs ;)