### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-fs-lwt.opam
+++ b/mirage-fs-lwt.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build}
+  "dune"
   "mirage-fs" {>= "1.0.0"}
   "mirage-kv-lwt" {>= "2.0.0"}
   "lwt"

--- a/mirage-fs.opam
+++ b/mirage-fs.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build}
+  "dune"
   "fmt"
   "mirage-device" {>= "1.0.0"}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.